### PR TITLE
Switch to https for deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
-       {proper, "1.0", {git, "git://github.com/manopapad/proper.git", {tag, "v1.0"}}},
-       {jsx, "1.4", {git, "git://github.com/talentdeficit/jsx", {tag, "v1.4"}}}
+       {proper, "1.0", {git, "https://github.com/manopapad/propert", {tag, "v1.0"}}},
+       {jsx, "1.4", {git, "https://github.com/talentdeficit/jsx", {tag, "v1.4"}}}
 ]}.
 
 {eunit_opts, [verbose]}.


### PR DESCRIPTION
Using https for dependencies on GitHub is preferable, as some poor saps (like me) are stuck behind corporate firewalls, which block the git protocol.

Doing a quick search this is a very common thing to block, oddly enough. Using https doesn't negatively impact the normal use case, either.
