### PR TITLE
Do not convert boolean to string

### DIFF
--- a/src/rec2json.erl
+++ b/src/rec2json.erl
@@ -98,6 +98,8 @@ to_json(Tuple, Options) when is_tuple(Tuple) ->
                     {UndefIs, Acc};
                 {ok, undefined} when UndefIs =:= null ->
                     {UndefIs, [{Name, null} | Acc]};
+                {ok, NewVal} when is_boolean(NewVal) ->
+                    {UndefIs, [{Name, NewVal} | Acc]};
                 {ok, NewVal} when is_atom(NewVal) ->
                     {UndefIs, [{Name, list_to_binary(atom_to_list(NewVal))} | Acc]};
                 {ok, NewVal} ->

--- a/test/r2j_compile_tests.erl
+++ b/test/r2j_compile_tests.erl
@@ -236,6 +236,18 @@ feature_test_() ->
           ?assertEqual([{field, <<"an atom">>}], Record:to_json())
         end},
 
+        {"To json, true does not become binary", fun() ->
+          ?debugFmt("~p", [proplists:get_value(r2j_compile, code:all_loaded())]),
+          Record = #included{field = true},
+          ?assertEqual([{field, true}], Record:to_json())
+        end},
+
+        {"To json, false does not become binary", fun() ->
+          ?debugFmt("~p", [proplists:get_value(r2j_compile, code:all_loaded())]),
+          Record = #included{field = false},
+          ?assertEqual([{field, false}], Record:to_json())
+        end},
+
         {"To json, empty lists stay lists", fun() ->
           Record = #included{field = []},
           ?assertEqual([{field, []}], Record:to_json())


### PR DESCRIPTION
Atoms 'true' and 'false' should not be converted to binaries, corresponding to "Converting JSON to Erlang" part of http://www.erlang.org/eeps/eep-0018.html
