### PR TITLE
unsafe atom conversion type provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,17 @@ Currently defined types checked:
 * binary()
 * [supported_type()]
 * #record{} when record has record:from_json/2 exported
-* atom (note it is not atom())
+* atom (note it is not atom())*
 * null when converting to undefined or back
+
+The type `atom()` is not supported because a primary use case for rec2json
+is to convert untrusted data, such as an http post request. Converting
+untrusted data into atoms can exhaust the erlang vm's atom table, or worse
+exhaust the machine's memory. Rec2json is, by default, safe.
+
+It is still possilbe to apply a type to a record field so that json strings
+will be converted to the equivalent atom using either a user defined type,
+or the provied `r2j_type:unsafe_atom()` type.
 
 ### User defined types
 

--- a/test/r2j_type_tests.erl
+++ b/test/r2j_type_tests.erl
@@ -83,4 +83,18 @@ prop_float() ->
         Expected == Got
     end).
 
+prop_unsafe_atom() ->
+    ?FORALL(Val, oneof([<<"bin1">>, <<"bin2">>, 1, 2.0]),
+    begin
+        Expected = if
+            is_binary(Val) ->
+                {ok, binary_to_atom(Val, utf8)};
+            true ->
+                error
+        end,
+        Got = r2j_type:unsafe_atom(Val),
+        Expected == Got
+    end).
+
+
 -endif.


### PR DESCRIPTION
Added a type, `r2j_type:unsafe_atom()` to provide a user defined type / converter that takes json strings and converts them to the equivalent atom. This means that one can disable the safe behavior of rec2json out of the box, better inform other developers about that choice, and rec2json remains safe by default.