### PR TITLE
Create user defined type automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ used as a paramterized module, making it simple to use with the
 
 Options are passed to the rec2json parse transform through compile options.
 The parse transform checks for the key 'rec2json' in the compile options.
-The value is expected to be a proplist. Options are:
+The value is expected to be a proplist. 
+
+Options can also be passed in on a per-module basis by adding one or more
+`rec2json` module attributes. A `rec2json` module attribute can either be a
+tuple for one option, or a list of option tuples. They all get mashed together.
+Using the same option more than once has undefined behavior.
+
+Options are:
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ rec2json's parse transform avoid altering or adding functions that are
 already defined in the module. This means you can override the default
 to_json/1 function to call to_json/2 with a specific set of options.</td>
 	</tr>
+    <tr>
+        <td>generate_property</td> <td>true : boolean()</td> <td> If set to
+true, a type is generated for the record, and that type is exported. In
+addition, a function is generated so that other rec2json records using the
+exported type work as expected</td>
+    </tr>
+    <tr>
+        <td>property_name</td> <td> ?MODULE : atom()</td> <td> If
+generate_property is true, this changes the type name and the function name for
+the conversion function.</td>
+    </tr>
 </table>
 
 The given examples use the following record and record defintion:

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ already defined in the module. This means you can override the default
 to_json/1 function to call to_json/2 with a specific set of options.</td>
 	</tr>
     <tr>
-        <td>generate_property</td> <td>true : boolean()</td> <td> If set to
+        <td>generate_type</td> <td>true : boolean()</td> <td> If set to
 true, a type is generated for the record, and that type is exported. In
 addition, a function is generated so that other rec2json records using the
 exported type work as expected</td>
     </tr>
     <tr>
-        <td>property_name</td> <td> ?MODULE : atom()</td> <td> If
-generate_property is true, this changes the type name and the function name for
-the conversion function.</td>
+        <td>type_name</td> <td> ?MODULE : atom()</td> <td> If generate_type is
+true, this changes the type name and the function name for the conversion
+function.</td>
     </tr>
 </table>
 

--- a/src/r2j_compile.erl
+++ b/src/r2j_compile.erl
@@ -249,21 +249,21 @@ create_module(RecordName, Fields, Params) ->
     [ModuleDeclaration, ExportDeclaration] ++ NewFunctions.
 
 type_declaration(RecordName, Params) ->
-    case proplists:get_value(generate_property, Params, true) of
+    case proplists:get_value(generate_type, Params, true) of
         false ->
             {ok, []};
         true ->
-            PropertyName = proplists:get_value(property_name, Params, RecordName),
+            PropertyName = proplists:get_value(type_name, Params, RecordName),
             Attr = {attribute, 1, type, {PropertyName, {type, 1, record, [{atom, 1, RecordName}]},[]}},
             {ok, [Attr]}
     end.
 
 export_type_declaration(RecordName, Params) ->
-    case proplists:get_value(generate_property, Params, true) of
+    case proplists:get_value(generate_type, Params, true) of
         false ->
             {ok, []};
         true ->
-            PropertyName = proplists:get_value(property_name, Params, RecordName),
+            PropertyName = proplists:get_value(type_name, Params, RecordName),
             Attr = {attribute, 1, export_type, [{PropertyName, 0}]},
             {ok, [Attr]}
     end.
@@ -279,10 +279,10 @@ additional_funcs(RecordName, Fields, Params) ->
         true -> setter_funcs(Fields);
         false -> []
     end,
-    GenerateProperty = proplists:get_value(generate_property, Params, true),
+    GenerateProperty = proplists:get_value(generate_type, Params, true),
     Converter = case GenerateProperty of
         true ->
-            ProperyName = proplists:get_value(property_name, Params, RecordName),
+            ProperyName = proplists:get_value(type_name, Params, RecordName),
             [converter_func(RecordName, ProperyName, length(Fields))];
         false -> []
     end,
@@ -326,10 +326,10 @@ export_declaration(RecordName, Fields, Params) ->
         true -> lists:map(fun setter_export_declaration/1, Fields);
         false -> []
     end,
-    GenerateProperty = proplists:get_value(generate_property, Params, true),
+    GenerateProperty = proplists:get_value(generate_type, Params, true),
     Converter = case GenerateProperty of
         true ->
-            PropertyName = proplists:get_value(property_name, Params, RecordName),
+            PropertyName = proplists:get_value(type_name, Params, RecordName),
             [{PropertyName, 1}];
         false -> []
     end,

--- a/src/r2j_type.erl
+++ b/src/r2j_type.erl
@@ -8,7 +8,7 @@
 -export([string/2]).
 
 -type unsafe_atom() :: atom().
--export_types([
+-export_type([
     unsafe_atom/0
 ]).
 

--- a/test/careful_tests.erl
+++ b/test/careful_tests.erl
@@ -9,6 +9,8 @@
 -record(careful_tests, {
 	one_field
 }).
+-type careful_tests() :: #careful_tests{}.
+-export_type([careful_tests/0]).
 
 % the real test is if this compiles or not. By deafult, rec2json should
 % not stomp on existing functions, even if this would prevent the module

--- a/test/careful_tests.erl
+++ b/test/careful_tests.erl
@@ -4,7 +4,7 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
--export([to_json/1]).
+-export([to_json/1, careful_tests/1]).
 
 -record(careful_tests, {
 	one_field
@@ -22,5 +22,11 @@ is_careful_test() -> ?assert(true).
 to_json_test() ->
 	Rec = #careful_tests{one_field = <<"yo">>},
 	?assertEqual([{}], to_json(Rec)).
+
+careful_tests(Value) ->
+	{ok, ok, Value}.
+
+use_careful_tests_function_test() ->
+	?assertEqual({ok, ok, <<"data">>}, careful_tests(<<"data">>)).
 
 -endif.

--- a/test/default_property.erl
+++ b/test/default_property.erl
@@ -1,5 +1,5 @@
 -module(default_property).
--compile([{parse_transfrom, rec2json}]).
+-compile([{parse_transform, rec2json}]).
 
 -record(default_property, {
 	f1 = 1 :: integer(),

--- a/test/default_property.erl
+++ b/test/default_property.erl
@@ -1,0 +1,7 @@
+-module(default_property).
+-compile([{parse_transfrom, rec2json}]).
+
+-record(default_property, {
+	f1 = 1 :: integer(),
+	f2 = <<"hi">> :: binary()
+}).

--- a/test/r2j_compile_tests.erl
+++ b/test/r2j_compile_tests.erl
@@ -97,11 +97,7 @@ types_gen([{Nth, Type} | Tail]) ->
     {generator, fun() -> [{Type, Test} | {generator, Generator}] end}.
 
 parse_transform_test_() ->
-    {setup, fun() ->
-        ok
-    end, fun(_) ->
-        ok
-    end, fun(_) -> [
+    [
 
         {"compile", fun() ->
             Got = compile:file("../test/test_rec"),
@@ -204,9 +200,41 @@ parse_transform_test_() ->
         {"has to/from json", fun() ->
             ?assert(erlang:function_exported(test_person, to_json, 1)),
             ?assert(erlang:function_exported(test_person, from_json, 1))
+        end},
+
+        {"has default conversion function", fun() ->
+            Exported = default_property:module_info(exports),
+            ?assert(lists:member({default_property, 1}, Exported))
+        end},
+
+        {"default property conversion works as expected", fun() ->
+            InitialJson = [{}],
+            {ok, Record} = default_property:default_property(InitialJson),
+            1 = default_property:f1(Record),
+            <<"hi">> = default_property:f2(Record),
+            {ok, [{}]} = default_property:default_property(Record)
+        end},
+
+        {"property name can be altered", fun() ->
+            Exported = renamed_property:module_info(exports),
+            ?assert(lists:member({goober, 1}, Exported))
+        end},
+
+        {"renamed property works like default", fun() ->
+            InitialJson = [{}],
+            {ok, Record} = renamed_property:goober(InitialJson),
+            42 = renamed_property:f1(Record),
+            hello = renamed_property:f2(Record),
+            {ok, [{}]} = default_property:default_property(Record)
+
+        end},
+
+        {"property creation suppressed", fun() ->
+            Exported = suppress_property:module_info(exports),
+            ?assertNot(lists:member({suppress_property, 1}, Exported))
         end}
 
-    ] end}.
+    ].
 
 feature_test_() ->
     {setup, fun() ->

--- a/test/r2j_compile_tests.erl
+++ b/test/r2j_compile_tests.erl
@@ -212,7 +212,8 @@ parse_transform_test_() ->
             {ok, Record} = default_property:default_property(InitialJson),
             1 = default_property:f1(Record),
             <<"hi">> = default_property:f2(Record),
-            {ok, [{}]} = default_property:default_property(Record)
+            EmptyRec = default_property:f1(undefined, default_property:f2(undefined, Record)),
+            {ok, [{}]} = default_property:default_property(EmptyRec)
         end},
 
         {"property name can be altered", fun() ->
@@ -225,7 +226,8 @@ parse_transform_test_() ->
             {ok, Record} = renamed_property:goober(InitialJson),
             42 = renamed_property:f1(Record),
             hello = renamed_property:f2(Record),
-            {ok, [{}]} = default_property:default_property(Record)
+            EmptyRec = renamed_property:f1(undefined, renamed_property:f2(undefined, Record)),
+            {ok, [{}]} = renamed_property:goober(EmptyRec)
 
         end},
 

--- a/test/renamed_property.erl
+++ b/test/renamed_property.erl
@@ -1,6 +1,6 @@
 -module(renamed_property).
 -compile({parse_transform, rec2json}).
--rec2json({property_name, goober}).
+-rec2json({type_name, goober}).
 
 -record(renamed_property, {
 	f1 = 42 :: pos_integer(),

--- a/test/renamed_property.erl
+++ b/test/renamed_property.erl
@@ -1,5 +1,6 @@
 -module(renamed_property).
--compile([{parse_transform, rec2json}, {rec2json, [{property_name, goober}]}]).
+-compile({parse_transform, rec2json}).
+-rec2json({property_name, goober}).
 
 -record(renamed_property, {
 	f1 = 42 :: pos_integer(),

--- a/test/renamed_property.erl
+++ b/test/renamed_property.erl
@@ -1,0 +1,7 @@
+-module(renamed_property).
+-compile([{parse_transform, rec2json}, {rec2json, [{property_name, goober}]}]).
+
+-record(renamed_property, {
+	f1 = 42 :: pos_integer(),
+	f2 = hello :: hello | hi | yo | hey
+}).

--- a/test/suppress_property.erl
+++ b/test/suppress_property.erl
@@ -1,5 +1,6 @@
 -module(suppress_property).
--compile([{parse_transform, rec2json}, {rec2json, [{generate_property, false}]}]).
+-compile({parse_transform, rec2json}).
+-rec2json([{generate_property, false}]).
 
 -record(suppress_property, {
 	f1 = <<"hello">> :: binary(),

--- a/test/suppress_property.erl
+++ b/test/suppress_property.erl
@@ -1,0 +1,7 @@
+-module(suppress_property).
+-compile([{parse_transform, rec2json}, {rec2json, [{generate_property, false}]}]).
+
+-record(suppress_property, {
+	f1 = <<"hello">> :: binary(),
+	f2 = 7 :: number()
+}).

--- a/test/suppress_property.erl
+++ b/test/suppress_property.erl
@@ -1,6 +1,6 @@
 -module(suppress_property).
 -compile({parse_transform, rec2json}).
--rec2json([{generate_property, false}]).
+-rec2json([{generate_type, false}]).
 
 -record(suppress_property, {
 	f1 = <<"hello">> :: binary(),


### PR DESCRIPTION
Given the following module:

```erlang
-module(r).
-compile({parse_transform, rec2json}).
-record(r, {f1, f2}).
```

This will add:

```erlang
-type r() :: #r{}.
-export_type([r/0]).
-export([r/0]).
r(Input) when is_json(Input) ->
    from_json(Input);
r(Input) when is_record(Input) ->
    {ok, to_json(Input)}.
```

This can be suppressed, and the type name can be changed.