### PR TITLE
Update the proper's version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [
-       {proper, "1.1", {git, "https://github.com/manopapad/proper", {branch, "master"}}},
+       {proper, "1.2", {git, "https://github.com/manopapad/proper", {branch, "master"}}},
        {jsx, "2.4.0", {git, "https://github.com/talentdeficit/jsx", {tag, "v2.4.0"}}}
 ]}.
 


### PR DESCRIPTION
[proper](https://github.com/manopapad/proper/releases) release new version: 1.2 . The old rebar.config can't be work.