### PR TITLE
Fix Rebar Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/*.beam
 .local_dialyzer_plt
 .erlang.mk
 rec2json.d
+.rec2json.plt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: erlang
 otp_release:
   - 18.0
   - 17.0
+
+script: make tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rec2json
 PROJECT_DESCRIPTION = Compile erlang record definitions into modules to convert them to/from json easily.
-PROJECT_VERSION = 3.2.0
+PROJECT_VERSION = 3.2.1
 
 TEST_DEPS = proper jsx
 dep_proper = git https://github.com/manopapad/proper master

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,6 @@ TEST_DEPS = proper jsx
 dep_proper = git https://github.com/manopapad/proper master
 dep_jsx = git https://github.com/talentdeficit/jsx v2.4.0
 
+app:: rebar.config
+
 include erlang.mk

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,4 @@ TEST_DEPS = proper jsx
 dep_proper = git https://github.com/manopapad/proper master
 dep_jsx = git https://github.com/talentdeficit/jsx v2.4.0
 
-app:: rebar.config
-
 include erlang.mk

--- a/ebin/rec2json.app
+++ b/ebin/rec2json.app
@@ -1,0 +1,7 @@
+{application, rec2json, [
+	{description, "Compile erlang record definitions into modules to convert them to/from json easily."},
+	{vsn, "3.2.0"},
+	{modules, ['r2j_compile','r2j_type','rec2json']},
+	{registered, []},
+	{applications, [kernel,stdlib]}
+]}.

--- a/ebin/rec2json.app
+++ b/ebin/rec2json.app
@@ -1,6 +1,6 @@
 {application, rec2json, [
 	{description, "Compile erlang record definitions into modules to convert them to/from json easily."},
-	{vsn, "3.2.0"},
+	{vsn, "3.2.1"},
 	{modules, ['r2j_compile','r2j_type','rec2json']},
 	{registered, []},
 	{applications, [kernel,stdlib]}

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,4 @@
+{deps, [
+
+]}.
+{erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{proper,".*",{git,"https://github.com/manopapad/proper","master"}},{jsx,".*",{git,"https://github.com/talentdeficit/jsx","v2.4.0"}}
+
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-
+{proper,".*",{git,"https://github.com/manopapad/proper","master"}},{jsx,".*",{git,"https://github.com/talentdeficit/jsx","v2.4.0"}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.


### PR DESCRIPTION
Moving to erlang.mk broke support rebar, so we're going to fix that as rebar is still a widely used build too.