### PR TITLE
Use Maps as Json representation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: erlang
 otp_release:
+  - 20.0
+  - 19.0
   - 18.0
-  - 17.0
 
 script: make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: erlang
 otp_release:
   - 20.0
   - 19.0
-  - 18.0
 
 script: make tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rec2json
 PROJECT_DESCRIPTION = Compile erlang record definitions into modules to convert them to/from json easily.
-PROJECT_VERSION = 3.2.1
+PROJECT_VERSION = 4.0.0
 
 TEST_DEPS = proper jsx
 dep_proper = git https://github.com/manopapad/proper master

--- a/ebin/rec2json.app
+++ b/ebin/rec2json.app
@@ -1,6 +1,6 @@
 {application, rec2json, [
 	{description, "Compile erlang record definitions into modules to convert them to/from json easily."},
-	{vsn, "3.2.1"},
+	{vsn, "4.0.0"},
 	{modules, ['r2j_compile','r2j_type','rec2json']},
 	{registered, []},
 	{applications, [kernel,stdlib]}

--- a/test/careful_tests.erl
+++ b/test/careful_tests.erl
@@ -23,7 +23,7 @@ is_careful_test() -> ?assert(true).
 
 to_json_test() ->
 	Rec = #careful_tests{one_field = <<"yo">>},
-	?assertEqual([{}], to_json(Rec)).
+	?assertEqual(#{}, to_json(Rec)).
 
 careful_tests(Value) ->
 	{ok, ok, Value}.

--- a/test/default_value_tests.erl
+++ b/test/default_value_tests.erl
@@ -33,12 +33,12 @@
 
 make_default() ->
     make_default(ok).
-    
+
 make_default(Val) ->
     {default, Val}.
 
 defaults_test_() ->
-    {ok, Rec} = default_value_tests:from_json([{}]),
+    {ok, Rec} = default_value_tests:from_json(#{}),
 
     Expectations = [
         {integer_no_type, 3},

--- a/test/prop_test_rec.erl
+++ b/test/prop_test_rec.erl
@@ -1,0 +1,4 @@
+-module(prop_test_rec).
+-compile([{parse_transform, rec2json}]).
+
+-include("prop_test_rec.hrl").

--- a/test/prop_test_rec.hrl
+++ b/test/prop_test_rec.hrl
@@ -1,0 +1,30 @@
+
+-include("prop_test_rec_inner.hrl").
+
+-type user_type() :: user_type.
+
+-record(prop_test_rec, {
+	prop_integer :: integer(),
+	prop_pos_integer :: pos_integer(),
+	prop_int_or_bool :: integer() | boolean(),
+	prop_atoms :: init | ready | steady,
+	prop_non_neg_integer :: non_neg_integer(),
+	prop_boolean :: boolean(),
+	prop_neg_integer :: neg_integer(),
+	prop_number :: number(),
+	prop_binary :: binary(),
+	prop_float :: float(),
+	prop_list_one :: [integer()],
+	prop_record_one_inner :: #prop_test_rec_inner{},
+	prop_record_list :: [#prop_test_rec_inner{}],
+	prop_user_type :: user_type(),
+	prop_user_type_default = 3 :: user_type(),
+	prop_user_type_list :: [user_type()],
+	prop_r2j_integer_type :: r2j_type:integer(),
+	prop_r2j_integer_min_max_type :: r2j_type:integer(-100, 100),
+	prop_r2j_integer_min_max_listed :: [r2j_type:integer(-100, 100)],
+	type_translation :: r2j_compile_tests:point(),
+	prop_null :: null,
+	prop_any,
+	prop_int_with_default = 1 :: integer()
+}).

--- a/test/prop_test_rec_inner.erl
+++ b/test/prop_test_rec_inner.erl
@@ -1,0 +1,4 @@
+-module(prop_test_rec_inner).
+-compile([{parse_transform, rec2json}]).
+
+-include("prop_test_rec_inner.hrl").

--- a/test/prop_test_rec_inner.hrl
+++ b/test/prop_test_rec_inner.hrl
@@ -1,0 +1,1 @@
+-record(prop_test_rec_inner, {f :: integer()}).

--- a/test/rec2json_tests.erl
+++ b/test/rec2json_tests.erl
@@ -41,25 +41,25 @@ feature_test_() -> [
 
 		{"does to_json conversion correctly", fun() ->
 			Rec = #rec2json_tests{typed_field = {2, 3, 4}, untyped_field = <<"hi">>},
-			Expected = [{typed_field, [2, 3, 4]}, {untyped_field, <<"hi">>}, {float_field, 1.0}, {rec_field_list, []}],
+			Expected = #{typed_field => [2, 3, 4], untyped_field => <<"hi">>, float_field => 1.0, rec_field_list => []},
 			Got = ?MODULE:to_json(Rec),
 			?assertEqual(Expected, Got)
 		end},
 
 		{"does from_json conversion correctly", fun() ->
-			Json = [{<<"typed_field">>, [4, 3, 2]}, {<<"untyped_field">>, <<"bye">>}],
+			Json = #{<<"typed_field">> => [4, 3, 2], <<"untyped_field">> => <<"bye">>},
 			Expected = #rec2json_tests{typed_field = {4, 3, 2}, untyped_field = <<"bye">>},
 			Got = ?MODULE:from_json(Json),
 			?assertEqual({ok, Expected}, Got)
 		end},
 
 		{"skips over non-rec2json records", fun() ->
-			Json = [{rec_field_list, [
-				[{f, 1}],
-				[{f, 2}],
-				[{f, 3}]
-			]}],
-			Expected = #rec2json_tests{rec_field_list = [[{f, 1}], [{f, 2}], [{f, 3}]]},
+			Json = #{rec_field_list => [
+				#{f => 1},
+				#{f => 2},
+				#{f => 3}
+			]},
+			Expected = #rec2json_tests{rec_field_list = [#{f => 1}, #{f => 2}, #{f => 3}]},
 			% we still get warnings because the type spec of the list does not
 			% have a valid type that matches the json (like any()).
 			ExpectedWarnings = [
@@ -73,7 +73,7 @@ feature_test_() -> [
 
 		{"if a field is skipped, don't bother to verify it's type", fun() ->
 			Record = #rec2json_tests{rec_field_list = {not_valid}},
-			Expected = [{typed_field, [1]}, {untyped_field, 3}, {float_field, 1.0}],
+			Expected = #{typed_field => [1], untyped_field => 3, float_field => 1.0},
 			Got = ?MODULE:to_json([rec_field_list], Record),
 			?assertEqual(Expected, Got)
 		end},
@@ -82,9 +82,9 @@ feature_test_() -> [
 			code:delete(r2j_type),
 			code:purge(r2j_type),
 			false = code:is_loaded(r2j_type),
-    	Rec = #?MODULE{},
-			Got = Rec:to_json(),
-			?assertEqual(1.0, proplists:get_value(float_field, Got))
+    		Rec = #?MODULE{},
+			Got = ?MODULE:to_json(Rec),
+			?assertEqual(1.0, maps:get(float_field, Got))
 		end}
 
 	].


### PR DESCRIPTION
This is a movement to version 4, as well as addressing #22 . Changes:

- Maps are used for Json objects rather than proplists. There is no support for proplists in this version.
- As part of the above, mutators must accept maps and return maps.
- Setting properties can be done by a 2-tuple, or a map.
- The scan_string and scan_file functions, which were strongly discouraged, are now removed.
- Removed support for Erlang 17