### PR TITLE
Support erl 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
+  - 21.0
   - 20.0
   - 19.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rec2json
 PROJECT_DESCRIPTION = Compile erlang record definitions into modules to convert them to/from json easily.
-PROJECT_VERSION = 4.0.0
+PROJECT_VERSION = 4.0.1
 
 TEST_DEPS = proper jsx
 dep_proper = git https://github.com/manopapad/proper master

--- a/ebin/rec2json.app
+++ b/ebin/rec2json.app
@@ -1,6 +1,6 @@
 {application, rec2json, [
 	{description, "Compile erlang record definitions into modules to convert them to/from json easily."},
-	{vsn, "4.0.0"},
+	{vsn, "4.0.1"},
 	{modules, ['r2j_compile','r2j_type','rec2json']},
 	{registered, []},
 	{applications, [kernel,stdlib]}

--- a/test/default_value_tests.erl
+++ b/test/default_value_tests.erl
@@ -63,11 +63,39 @@ defaults_test_() ->
     ],
 
     lists:map(fun({Field, Value}) ->
-        Name = iolist_to_binary(io_lib:format("ensure ~p is ~p", [Field, Value])),
-        {Name, fun() ->
-            ?assertEqual(Value, erlang:apply(Rec, Field, []))
-        end}
+        create_default_test(Field, Value, Rec)
     end, Expectations).
+
+-ifdef(OTP_RELEASE).
+
+    -if(?OTP_RELEASE >= 21).
+
+create_default_test(Field, Value, Rec) ->
+    Name = iolist_to_binary(io_lib:format("ensure ~p is ~p", [Field, Value])),
+    {Name, fun() ->
+        ?assertEqual(Value, erlang:apply(?MODULE, Field, [Rec]))
+    end}.
+
+    -else.
+
+create_default_test(Field, Value, Rec) ->
+    Name = iolist_to_binary(io_lib:format("ensure ~p is ~p", [Field, Value])),
+    {Name, fun() ->
+        ?assertEqual(Value, erlang:apply(?MODULE, Field, [Rec])),
+        ?assertEqual(Value, erlang:apply(Rec, Field, []))
+    end}.
+
+    -endif.
+
+-else.
+
+create_default_test(Field, Value, Rec) ->
+    Name = iolist_to_binary(io_lib:format("ensure ~p is ~p", [Field, Value])),
+    {Name, fun() ->
+        ?assertEqual(Value, erlang:apply(?MODULE, Field, [Rec])),
+        ?assertEqual(Value, erlang:apply(Rec, Field, []))
+    end}.
 
 -endif.
 
+-endif.


### PR DESCRIPTION
Some tests used Erlang:apply/3 but passed in a tuple as the first argument. This refactors those tests.